### PR TITLE
feat(testhub): live reflection of projectbluefin/testhub build pipeline

### DIFF
--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -103,12 +103,27 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./stats-go/stats fetch-brewfile-taps
 
+      - name: Restore testhub history cache
+        uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: .sync-cache/testhub-history.json
+          key: testhub-history-v1-${{ github.run_id }}
+          restore-keys: testhub-history-v1-
+
       - name: Fetch Testhub package stats
         id: sync-testhub
         continue-on-error: true
+        timeout-minutes: 5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./stats-go/stats fetch-testhub
+
+      - name: Save testhub history cache
+        if: always()
+        uses: actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: .sync-cache/testhub-history.json
+          key: testhub-history-v1-${{ github.run_id }}
 
       - name: Fetch countme active-user stats
         id: sync-countme
@@ -286,6 +301,8 @@ jobs:
           pkg_count=$(jq '.packages | length' src/data/testhub.json 2>/dev/null || echo 0)
           metric_count=$(jq '.build_metrics | length' src/data/testhub.json 2>/dev/null || echo 0)
           known=$(jq '[.build_metrics[] | select(.last_status != "unknown" and .last_status != "")] | length' src/data/testhub.json 2>/dev/null || echo 0)
+          stale_count=$(jq '[.build_metrics[] | select(.last_status == "stale")] | length' src/data/testhub.json 2>/dev/null || echo 0)
+          pending_count=$(jq '[.build_metrics[] | select(.last_status == "pending")] | length' src/data/testhub.json 2>/dev/null || echo 0)
           last_hist_date=$(jq -r '[.history[].date] | max // ""' src/data/testhub.json 2>/dev/null || echo "")
           stale_days=""
           if [ -n "$last_hist_date" ]; then
@@ -297,6 +314,8 @@ jobs:
           fi
           echo "  packages: $pkg_count"
           echo "  build_metrics: $metric_count"
+          echo "  stale (>7d silent): $stale_count"
+          echo "  pending (no history): $pending_count"
           if [ "$pkg_count" -gt 0 ]; then
             echo "✅ testhub.packages = $pkg_count"
           else

--- a/Justfile
+++ b/Justfile
@@ -23,6 +23,7 @@ sync:
     cd stats-go && go build -o stats ./cmd/stats/
     GITHUB_TOKEN="${GITHUB_TOKEN:-$GITHUB_PAT}" ./stats-go/stats
     GITHUB_TOKEN="${GITHUB_TOKEN:-$GITHUB_PAT}" ./stats-go/stats fetch-brewfile-taps
+    GITHUB_TOKEN="${GITHUB_TOKEN:-$GITHUB_PAT}" ./stats-go/stats fetch-testhub
     GITHUB_TOKEN="${GITHUB_TOKEN:-$GITHUB_PAT}" ./stats-go/stats fetch-releases
     just sync-builds
 

--- a/src/components/TesthubBuildChart.astro
+++ b/src/components/TesthubBuildChart.astro
@@ -4,7 +4,17 @@ import { safeJson } from '../lib/inject.ts';
 
 interface DaySnapshot {
   date: string;
-  build_counts: { app: string; passed: number; failed: number; total: number }[] | null;
+  build_counts: {
+    app: string;
+    passed: number;
+    failed: number;
+    passed_aarch64?: number;
+    failed_aarch64?: number;
+    sign_failed?: number;
+    publish_failed?: number;
+    annotate_failed?: number;
+    total: number;
+  }[] | null;
 }
 
 interface Props {
@@ -17,8 +27,17 @@ const series = [...history]
   .slice(-30)
   .map((snapshot) => {
     const counts = snapshot.build_counts ?? [];
-    const passed = counts.reduce((sum, item) => sum + (item.passed ?? 0), 0);
-    const failed = counts.reduce((sum, item) => sum + (item.failed ?? 0), 0);
+    const passed = counts.reduce((sum, item) => sum + (item.passed ?? 0) + (item.passed_aarch64 ?? 0), 0);
+    const failed = counts.reduce(
+      (sum, item) =>
+        sum +
+        (item.failed ?? 0) +
+        (item.failed_aarch64 ?? 0) +
+        (item.sign_failed ?? 0) +
+        (item.publish_failed ?? 0) +
+        (item.annotate_failed ?? 0),
+      0,
+    );
     return {
       date: snapshot.date,
       passed,

--- a/src/components/TesthubKPIs.astro
+++ b/src/components/TesthubKPIs.astro
@@ -27,7 +27,7 @@ interface Props {
   generatedAt: string;
 }
 
-const { packages, buildMetrics, history } = Astro.props;
+const { packages, buildMetrics, history, generatedAt } = Astro.props;
 
 const totalPackages = packages.length;
 
@@ -63,6 +63,17 @@ const avgPassRate7d = passRateSamples.length > 0
   ? passRateSamples.reduce((sum, v) => sum + v, 0) / passRateSamples.length
   : null;
 ---
+
+<div id="freshness-banner" class="freshness-banner" style="display:none">
+  ⚠️ Dashboard data may be stale — last updated more than 48 hours ago.
+</div>
+<script define:vars={{ generatedAt }}>
+  const elapsed = Date.now() - new Date(generatedAt).getTime();
+  if (elapsed > 48 * 60 * 60 * 1000) {
+    const banner = document.getElementById('freshness-banner');
+    if (banner) banner.style.display = 'block';
+  }
+</script>
 
 <div class="hero-kpis">
   <div class="kpi-card">
@@ -122,5 +133,14 @@ const avgPassRate7d = passRateSamples.length > 0
   }
   @media (max-width: 600px) {
     .kpi-card { flex: 1 1 calc(50% - 6px); }
+  }
+  .freshness-banner {
+    background: rgba(241, 194, 27, 0.15);
+    border: 1px solid #f1c21b;
+    border-radius: 6px;
+    padding: 10px 16px;
+    margin-bottom: 16px;
+    font-size: 13px;
+    color: #b45309;
   }
 </style>

--- a/src/components/TesthubKPIs.astro
+++ b/src/components/TesthubKPIs.astro
@@ -16,7 +16,17 @@ interface Package {
 
 interface DaySnapshot {
   date: string;
-  build_counts: { app: string; passed: number; failed: number; total: number }[];
+  build_counts: {
+    app: string;
+    passed: number;
+    failed: number;
+    passed_aarch64?: number;
+    failed_aarch64?: number;
+    sign_failed?: number;
+    publish_failed?: number;
+    annotate_failed?: number;
+    total: number;
+  }[];
   last_run_id: number;
 }
 

--- a/src/components/TesthubPackageTable.astro
+++ b/src/components/TesthubPackageTable.astro
@@ -4,6 +4,9 @@ interface BuildMetrics {
   last_status: string;
   last_build_at: string;
   pass_rate_7d: number;
+  pass_rate_30d: number;
+  arch_x86_status?: string;
+  arch_arm_status?: string;
 }
 
 interface Package {
@@ -24,10 +27,20 @@ const { packages, buildMetrics } = Astro.props;
 
 const metricsByApp = Object.fromEntries(buildMetrics.map(m => [m.app, m]));
 
-function statusBadge(status: string): string {
-  if (status === "passing") return "Passing";
-  if (status === "failing") return "Failing";
-  return "Unknown";
+function statusBadge(status: string): { label: string; cls: string } {
+  switch (status) {
+    case "passing": return { label: "✅ Passing", cls: "passing" };
+    case "failing": return { label: "❌ Failing", cls: "failing" };
+    case "stale":   return { label: "⚠️ Stale", cls: "stale" };
+    case "pending": return { label: "⏳ Pending", cls: "pending" };
+    default:        return { label: "Unknown", cls: "unknown" };
+  }
+}
+
+function archIcon(status?: string): string {
+  if (status === "passing") return "✅";
+  if (status === "failing") return "❌";
+  return "—";
 }
 
 function parseDate(value?: string): Date | null {
@@ -60,36 +73,45 @@ function relativeTime(value?: string): string {
         <thead>
           <tr>
             <th data-sort-key="name" class="sortable">Package ↕</th>
-            <th data-sort-key="version" class="sortable">Version ↕</th>
             <th data-sort-key="last_status" class="sortable">Build Status ↕</th>
-            <th data-sort-key="last_build_ts" class="sortable">Last Build ↕</th>
+            <th>Arch</th>
+            <th data-sort-key="last_published_ts" class="sortable">Last Published ↕</th>
           </tr>
         </thead>
         <tbody id="testhub-tbody">
           {packages.map(pkg => {
             const m = metricsByApp[pkg.name];
             const status = m?.last_status ?? "unknown";
+            const badge = statusBadge(status);
+            // Last Published: GHCR updated_at is primary; CI last_build_at is tooltip
+            const lastPublished = pkg.updated_at;
             const lastBuild = m?.last_build_at;
-            const lastBuildDate = parseDate(lastBuild);
-            // Use explicit version if available, otherwise fall back to build date (OCI tag proxy)
-            const displayVersion = pkg.version ?? lastBuild ?? "—";
+            const lastPublishedDate = parseDate(lastPublished);
+            const lastPublishedTs = lastPublishedDate ? lastPublishedDate.getTime() : 0;
+            const x86 = archIcon(m?.arch_x86_status);
+            const arm = archIcon(m?.arch_arm_status);
             return (
               <tr
                 data-name={pkg.name}
-                data-version={displayVersion}
                 data-last_status={status}
-                data-last_build_ts={lastBuildDate ? lastBuildDate.getTime() : 0}
+                data-last_published_ts={lastPublishedTs}
               >
                 <td>
                   {pkg.html_url
                     ? <a href={pkg.html_url} target="_blank" rel="noopener">{pkg.name}</a>
                     : pkg.name}
                 </td>
-                <td>{displayVersion}</td>
                 <td>
-                  <span class={`status-badge ${status}`}>{statusBadge(status)}</span>
+                  <span class={`status-badge ${badge.cls}`}>{badge.label}</span>
                 </td>
-                <td title={lastBuild ?? "No data"}>{relativeTime(lastBuild)}</td>
+                <td class="arch-cell">
+                  <span title="x86_64">{x86} x86</span>
+                  {" "}
+                  <span title="aarch64">{arm} arm</span>
+                </td>
+                <td title={lastBuild ? `CI build: ${lastBuild}` : "No CI data"}>
+                  {relativeTime(lastPublished)}
+                </td>
               </tr>
             );
           })}
@@ -120,7 +142,7 @@ function relativeTime(value?: string): string {
       rows.sort((a, b) => {
         const aVal = a.dataset[sortKey] ?? '';
         const bVal = b.dataset[sortKey] ?? '';
-        if (sortKey === 'last_build_ts') {
+        if (sortKey === 'last_published_ts') {
           return (Number(aVal) - Number(bVal)) * sortDir;
         }
         return aVal.localeCompare(bVal) * sortDir;
@@ -142,6 +164,7 @@ function relativeTime(value?: string): string {
   a { color: var(--link); text-decoration: none; }
   a:hover { text-decoration: underline; }
   .chart-empty { text-align: center; color: var(--muted); padding: 3rem 0; font-size: 14px; }
+  .arch-cell { white-space: nowrap; font-size: 12px; color: var(--muted); }
   .status-badge {
     display: inline-flex;
     align-items: center;
@@ -160,6 +183,15 @@ function relativeTime(value?: string): string {
     border-color: #da1e28;
     color: #fa4d56;
     background: rgba(250, 77, 86, 0.12);
+  }
+  .status-badge.stale {
+    border-color: #f1c21b;
+    color: #b45309;
+    background: rgba(241, 194, 27, 0.12);
+  }
+  .status-badge.pending {
+    color: var(--muted);
+    background: var(--bg3);
   }
   .status-badge.unknown {
     color: var(--muted);

--- a/src/lib/testhub.ts
+++ b/src/lib/testhub.ts
@@ -2,6 +2,11 @@ export interface AppDayCount {
   app: string;
   passed: number;
   failed: number;
+  passed_aarch64?: number;
+  failed_aarch64?: number;
+  sign_failed?: number;
+  publish_failed?: number;
+  annotate_failed?: number;
   total: number;
 }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -24,6 +24,11 @@ export interface AppDayCount {
   app: string;
   passed: number;
   failed: number;
+  passed_aarch64?: number;
+  failed_aarch64?: number;
+  sign_failed?: number;
+  publish_failed?: number;
+  annotate_failed?: number;
   total: number;
 }
 

--- a/src/pages/testhub/index.astro
+++ b/src/pages/testhub/index.astro
@@ -18,7 +18,8 @@ const history = (data.history as any) ?? [];
     <h1>projectbluefin/testhub</h1>
     <div class="meta">
       Updated {generatedAt} ·
-      <a href="https://github.com/projectbluefin/testhub">projectbluefin/testhub</a>
+      <a href="https://github.com/projectbluefin/testhub">projectbluefin/testhub</a> ·
+      <a href="https://github.com/projectbluefin/testhub/actions/workflows/build.yml">View CI Runs →</a>
     </div>
     <p class="intro">
       Testhub tracks package publishing and CI build outcomes for projectbluefin apps. Use this page to quickly

--- a/stats-go/cmd/stats/main.go
+++ b/stats-go/cmd/stats/main.go
@@ -396,6 +396,20 @@ func runFetchTesthub() error {
 		buildMetrics = append(buildMetrics, bm)
 	}
 
+	// Ensure pkgs is populated before the pending backfill so fallback-only packages
+	// also receive "pending" status when both package APIs failed.
+	if pkgs == nil {
+		// Package listing failed (e.g. missing read:packages scope on GITHUB_TOKEN).
+		// Fall back to the committed src/data/testhub.json so the site always has
+		// package data instead of rendering an empty table.
+		if fallback := loadFallbackTesthubPackages(); len(fallback) > 0 {
+			pkgs = fallback
+			fmt.Fprintf(os.Stderr, "  using %d fallback packages from committed testhub.json\n", len(pkgs))
+		} else {
+			pkgs = []testhub.Package{}
+		}
+	}
+
 	// Backfill packages in flatpak inventory with no build history at all → "pending".
 	for _, pkg := range pkgs {
 		if !seenApps[pkg.Name] {
@@ -417,18 +431,6 @@ func runFetchTesthub() error {
 			fmt.Fprintf(os.Stderr, "  using %d fallback build metrics from committed testhub.json\n", len(buildMetrics))
 		} else {
 			buildMetrics = []testhub.BuildMetrics{}
-		}
-	}
-
-	if pkgs == nil {
-		// Package listing failed (e.g. missing read:packages scope on GITHUB_TOKEN).
-		// Fall back to the committed src/data/testhub.json so the site always has
-		// package data instead of rendering an empty table.
-		if fallback := loadFallbackTesthubPackages(); len(fallback) > 0 {
-			pkgs = fallback
-			fmt.Fprintf(os.Stderr, "  using %d fallback packages from committed testhub.json\n", len(pkgs))
-		} else {
-			pkgs = []testhub.Package{}
 		}
 	}
 	if store.Snapshots == nil {
@@ -479,39 +481,41 @@ func loadFallbackTesthubBuildMetrics() []testhub.BuildMetrics {
 }
 
 // computeArchStatus returns the last known x86_64 and aarch64 build status for an app.
-// Looks at the most recent snapshot that has build data for the app.
+// Walks snapshots newest-first and resolves each architecture independently — stops
+// only when both have been determined from actual build data.
 func computeArchStatus(snapshots []testhub.DaySnapshot, app string) (x86Status, armStatus string) {
 	sorted := make([]testhub.DaySnapshot, len(snapshots))
 	copy(sorted, snapshots)
 	sort.Slice(sorted, func(i, j int) bool { return sorted[i].Date > sorted[j].Date })
 
+	x86Status = "unknown"
+	armStatus = "unknown"
+
 	for _, snap := range sorted {
+		if x86Status != "unknown" && armStatus != "unknown" {
+			break
+		}
 		for _, c := range snap.BuildCounts {
 			if c.App != app {
 				continue
 			}
-			if c.Passed > 0 || c.Failed > 0 {
+			if x86Status == "unknown" && (c.Passed > 0 || c.Failed > 0) {
 				if c.Failed > 0 {
 					x86Status = "failing"
 				} else {
 					x86Status = "passing"
 				}
-			} else {
-				x86Status = "unknown"
 			}
-			if c.PassedAarch64 > 0 || c.FailedAarch64 > 0 {
+			if armStatus == "unknown" && (c.PassedAarch64 > 0 || c.FailedAarch64 > 0) {
 				if c.FailedAarch64 > 0 {
 					armStatus = "failing"
 				} else {
 					armStatus = "passing"
 				}
-			} else {
-				armStatus = "unknown"
 			}
-			return x86Status, armStatus
 		}
 	}
-	return "unknown", "unknown"
+	return x86Status, armStatus
 }
 
 type lastStatus struct {

--- a/stats-go/cmd/stats/main.go
+++ b/stats-go/cmd/stats/main.go
@@ -348,24 +348,64 @@ func runFetchTesthub() error {
 		}
 	}
 
-	// Compute build metrics for 7d and 30d windows; merge PassRate30d into results.
-	metrics7d := testhub.ComputeBuildMetrics(store.Snapshots, 7)
-	metrics30d := testhub.ComputeBuildMetrics(store.Snapshots, 30)
-	// Build a lookup for 30d rates.
-	rate30d := make(map[string]float64, len(metrics30d))
-	for _, m := range metrics30d {
-		rate30d[m.App] = m.PassRate30d
-	}
-	// Merge: fill PassRate30d and LastStatus/LastBuildAt.
+	// Compute build metrics for 7d and 30d windows.
+	// ComputeBuildMetrics now returns map[string]float64 (app → pass rate).
+	rates7d := testhub.ComputeBuildMetrics(store.Snapshots, 7)
+	rates30d := testhub.ComputeBuildMetrics(store.Snapshots, 30)
+
+	// Determine last known status and build date per app across all history.
 	lastStatusByApp := computeLastStatus(store.Snapshots)
-	buildMetrics := make([]testhub.BuildMetrics, 0, len(metrics7d))
-	for _, m := range metrics7d {
-		m.PassRate30d = rate30d[m.App]
-		if ls, ok := lastStatusByApp[m.App]; ok {
-			m.LastStatus = ls.status
-			m.LastBuildAt = ls.at
+
+	// Union of all apps in either window — apps only in 30d get "stale" status.
+	// Apps in neither window with a package inventory entry get "pending".
+	seenApps := make(map[string]bool)
+	buildMetrics := make([]testhub.BuildMetrics, 0)
+
+	// Add all apps from 7d window first.
+	for app, rate7d := range rates7d {
+		seenApps[app] = true
+		bm := testhub.BuildMetrics{
+			App:        app,
+			PassRate7d: rate7d,
+			PassRate30d: rates30d[app],
 		}
-		buildMetrics = append(buildMetrics, m)
+		if ls, ok := lastStatusByApp[app]; ok {
+			bm.LastStatus = ls.status
+			bm.LastBuildAt = ls.at
+		}
+		bm.Arch86Status, bm.ArchArmStatus = computeArchStatus(store.Snapshots, app)
+		buildMetrics = append(buildMetrics, bm)
+	}
+
+	// Add apps only in 30d window (stale — had history, builds went silent).
+	for app, rate30d := range rates30d {
+		if seenApps[app] {
+			continue
+		}
+		seenApps[app] = true
+		bm := testhub.BuildMetrics{
+			App:         app,
+			PassRate7d:  0,
+			PassRate30d: rate30d,
+			LastStatus:  "stale",
+		}
+		if ls, ok := lastStatusByApp[app]; ok {
+			bm.LastBuildAt = ls.at
+		}
+		bm.Arch86Status, bm.ArchArmStatus = computeArchStatus(store.Snapshots, app)
+		buildMetrics = append(buildMetrics, bm)
+	}
+
+	// Backfill packages in flatpak inventory with no build history at all → "pending".
+	for _, pkg := range pkgs {
+		if !seenApps[pkg.Name] {
+			buildMetrics = append(buildMetrics, testhub.BuildMetrics{
+				App:           pkg.Name,
+				LastStatus:    "pending",
+				Arch86Status:  "unknown",
+				ArchArmStatus: "unknown",
+			})
+		}
 	}
 
 	if len(buildMetrics) == 0 {
@@ -438,12 +478,50 @@ func loadFallbackTesthubBuildMetrics() []testhub.BuildMetrics {
 	return out.BuildMetrics
 }
 
+// computeArchStatus returns the last known x86_64 and aarch64 build status for an app.
+// Looks at the most recent snapshot that has build data for the app.
+func computeArchStatus(snapshots []testhub.DaySnapshot, app string) (x86Status, armStatus string) {
+	sorted := make([]testhub.DaySnapshot, len(snapshots))
+	copy(sorted, snapshots)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].Date > sorted[j].Date })
+
+	for _, snap := range sorted {
+		for _, c := range snap.BuildCounts {
+			if c.App != app {
+				continue
+			}
+			if c.Passed > 0 || c.Failed > 0 {
+				if c.Failed > 0 {
+					x86Status = "failing"
+				} else {
+					x86Status = "passing"
+				}
+			} else {
+				x86Status = "unknown"
+			}
+			if c.PassedAarch64 > 0 || c.FailedAarch64 > 0 {
+				if c.FailedAarch64 > 0 {
+					armStatus = "failing"
+				} else {
+					armStatus = "passing"
+				}
+			} else {
+				armStatus = "unknown"
+			}
+			return x86Status, armStatus
+		}
+	}
+	return "unknown", "unknown"
+}
+
 type lastStatus struct {
 	status string
 	at     string
 }
 
 // computeLastStatus returns the last known build status per app from snapshots.
+// A run is "failing" if compile-oci failed OR any downstream stage explicitly failed
+// (publish-manifest-list failure means the image is unpullable even if compile passed).
 func computeLastStatus(snapshots []testhub.DaySnapshot) map[string]lastStatus {
 	// Sort descending by date to find the most recent entry per app.
 	sorted := make([]testhub.DaySnapshot, len(snapshots))
@@ -457,10 +535,12 @@ func computeLastStatus(snapshots []testhub.DaySnapshot) map[string]lastStatus {
 				continue
 			}
 			status := "unknown"
-			if c.Passed > 0 && c.Failed == 0 {
-				status = "passing"
-			} else if c.Failed > 0 {
+			pipelineFailed := c.Failed > 0 || c.FailedAarch64 > 0 ||
+				c.SignFailed > 0 || c.PublishFailed > 0 || c.AnnotateFailed > 0
+			if pipelineFailed {
 				status = "failing"
+			} else if c.Passed > 0 || c.PassedAarch64 > 0 {
+				status = "passing"
 			}
 			result[c.App] = lastStatus{status: status, at: snap.Date}
 		}

--- a/stats-go/internal/testhub/collector.go
+++ b/stats-go/internal/testhub/collector.go
@@ -13,6 +13,13 @@ import (
 	ghcli "github.com/castrojo/bootc-ecosystem/internal/ghcli"
 )
 
+var (
+	// archRe matches compile-oci, sign-and-push, annotate-packages jobs with arch suffix.
+	archRe = regexp.MustCompile(`^(compile-oci|sign-and-push|annotate-packages) \((.+),\s*(x86_64|aarch64)\)$`)
+	// manifestRe matches publish-manifest-list jobs (no arch suffix).
+	manifestRe = regexp.MustCompile(`^publish-manifest-list \((.+)\)$`)
+)
+
 // parseJobApp extracts structured info from a CI job name.
 // Supported patterns:
 //
@@ -23,8 +30,6 @@ import (
 //
 // App names are normalized to lowercase. Returns (result, false) for unrecognised jobs.
 func parseJobApp(jobName string) (JobParseResult, bool) {
-	// Patterns with arch
-	archRe := regexp.MustCompile(`^(compile-oci|sign-and-push|annotate-packages) \((.+),\s*(x86_64|aarch64)\)$`)
 	if m := archRe.FindStringSubmatch(jobName); m != nil {
 		return JobParseResult{
 			App:     strings.ToLower(strings.TrimSpace(m[2])),
@@ -34,7 +39,6 @@ func parseJobApp(jobName string) (JobParseResult, bool) {
 		}, true
 	}
 	// publish-manifest-list has no arch suffix
-	manifestRe := regexp.MustCompile(`^publish-manifest-list \((.+)\)$`)
 	if m := manifestRe.FindStringSubmatch(jobName); m != nil {
 		return JobParseResult{
 			App:     strings.ToLower(strings.TrimSpace(m[1])),
@@ -216,7 +220,6 @@ func MergePackages(existing, fallback []Package) []Package {
 type ghRunRecord struct {
 	DatabaseID int64  `json:"databaseId"`
 	Status     string `json:"status"`
-	HeadBranch string `json:"headBranch"`
 }
 
 // ghJobRecord is the minimal shape from the jobs API.
@@ -233,7 +236,7 @@ func FetchBuildCounts(lastRunID int64) ([]AppDayCount, int64, error) {
 		"--repo", "projectbluefin/testhub",
 		"--workflow", "build.yml",
 		"--branch", "main",
-		"--json", "databaseId,status,headBranch",
+		"--json", "databaseId,status",
 		"--limit", "100")
 	if err != nil {
 		return nil, lastRunID, fmt.Errorf("listing workflow runs: %w", err)

--- a/stats-go/internal/testhub/collector.go
+++ b/stats-go/internal/testhub/collector.go
@@ -13,19 +13,37 @@ import (
 	ghcli "github.com/castrojo/bootc-ecosystem/internal/ghcli"
 )
 
-// parseJobApp extracts the app name from a job name like "compile-oci (ghostty, x86_64)".
-// Returns ("", false) if the job is aarch64 or doesn't match the pattern.
-func parseJobApp(jobName string) (string, bool) {
-	re := regexp.MustCompile(`^compile-oci \((.+),\s*(x86_64|aarch64)\)$`)
-	m := re.FindStringSubmatch(jobName)
-	if m == nil {
-		return "", false
+// parseJobApp extracts structured info from a CI job name.
+// Supported patterns:
+//
+//	compile-oci (app, x86_64|aarch64)
+//	sign-and-push (app, x86_64|aarch64)
+//	publish-manifest-list (app)
+//	annotate-packages (app, x86_64|aarch64)
+//
+// App names are normalized to lowercase. Returns (result, false) for unrecognised jobs.
+func parseJobApp(jobName string) (JobParseResult, bool) {
+	// Patterns with arch
+	archRe := regexp.MustCompile(`^(compile-oci|sign-and-push|annotate-packages) \((.+),\s*(x86_64|aarch64)\)$`)
+	if m := archRe.FindStringSubmatch(jobName); m != nil {
+		return JobParseResult{
+			App:     strings.ToLower(strings.TrimSpace(m[2])),
+			Stage:   m[1],
+			Arch:    m[3],
+			HasArch: true,
+		}, true
 	}
-	arch := m[2]
-	if arch != "x86_64" {
-		return "", false
+	// publish-manifest-list has no arch suffix
+	manifestRe := regexp.MustCompile(`^publish-manifest-list \((.+)\)$`)
+	if m := manifestRe.FindStringSubmatch(jobName); m != nil {
+		return JobParseResult{
+			App:     strings.ToLower(strings.TrimSpace(m[1])),
+			Stage:   "publish-manifest-list",
+			Arch:    "",
+			HasArch: false,
+		}, true
 	}
-	return strings.TrimSpace(m[1]), true
+	return JobParseResult{}, false
 }
 
 // isTesthubPackage reports whether the package name belongs to the testhub namespace.
@@ -198,6 +216,7 @@ func MergePackages(existing, fallback []Package) []Package {
 type ghRunRecord struct {
 	DatabaseID int64  `json:"databaseId"`
 	Status     string `json:"status"`
+	HeadBranch string `json:"headBranch"`
 }
 
 // ghJobRecord is the minimal shape from the jobs API.
@@ -208,13 +227,14 @@ type ghJobRecord struct {
 }
 
 // FetchBuildCounts fetches workflow run job results from projectbluefin/testhub
-// for runs with ID > lastRunID. Returns aggregated per-app counts and the new max run ID.
+// for completed main-branch runs with ID > lastRunID. Returns aggregated per-app counts and the new max run ID.
 func FetchBuildCounts(lastRunID int64) ([]AppDayCount, int64, error) {
 	out, err := ghcli.Run("run", "list",
 		"--repo", "projectbluefin/testhub",
 		"--workflow", "build.yml",
-		"--json", "databaseId,status",
-		"--limit", "50")
+		"--branch", "main",
+		"--json", "databaseId,status,headBranch",
+		"--limit", "100")
 	if err != nil {
 		return nil, lastRunID, fmt.Errorf("listing workflow runs: %w", err)
 	}
@@ -228,6 +248,12 @@ func FetchBuildCounts(lastRunID int64) ([]AppDayCount, int64, error) {
 	newMaxRunID := lastRunID
 
 	for _, run := range runs {
+		// Only process completed runs — in-progress runs would advance the cursor
+		// and never be reprocessed after completion (Bug 7B fix).
+		if run.Status != "completed" {
+			continue
+		}
+
 		runID := run.DatabaseID
 		if runID <= lastRunID {
 			continue
@@ -249,20 +275,48 @@ func FetchBuildCounts(lastRunID int64) ([]AppDayCount, int64, error) {
 			continue
 		}
 		for _, job := range jobs {
-			app, ok := parseJobApp(job.Name)
+			parsed, ok := parseJobApp(job.Name)
 			if !ok {
 				continue
 			}
+			app := parsed.App
 			if _, exists := counts[app]; !exists {
 				counts[app] = &AppDayCount{App: app}
 			}
-			switch job.Conclusion {
-			case "success":
-				counts[app].Passed++
-				counts[app].Total++
-			case "failure", "cancelled":
-				counts[app].Failed++
-				counts[app].Total++
+			c := counts[app]
+
+			switch parsed.Stage {
+			case "compile-oci":
+				// Compile-oci: count both failure AND cancelled (cascade origin)
+				switch job.Conclusion {
+				case "success":
+					if parsed.Arch == "x86_64" {
+						c.Passed++
+					} else {
+						c.PassedAarch64++
+					}
+					c.Total++
+				case "failure", "cancelled":
+					if parsed.Arch == "x86_64" {
+						c.Failed++
+					} else {
+						c.FailedAarch64++
+					}
+					c.Total++
+				}
+			case "sign-and-push":
+				// Non-compile: only count explicit "failure" (cancelled = cascade, not a sign failure)
+				if job.Conclusion == "failure" {
+					c.SignFailed++
+				}
+			case "publish-manifest-list":
+				if job.Conclusion == "failure" {
+					c.PublishFailed++
+				}
+			case "annotate-packages":
+				if job.Conclusion == "failure" {
+					c.AnnotateFailed++
+				}
 			}
 		}
 	}
@@ -304,10 +358,11 @@ func AppendSnapshot(store *HistoryStore, pkgs []Package, counts []AppDayCount, l
 }
 
 // ComputeBuildMetrics computes pass rates from raw snapshot counts over a rolling window.
+// Returns a map of app name → pass rate (0–100) for apps with activity in the window.
 // The window is relative to the most recent snapshot date (not time.Now()), so that
 // historical test data with fixed dates is handled consistently.
 // This is a pure function — no I/O.
-func ComputeBuildMetrics(snapshots []DaySnapshot, windowDays int) []BuildMetrics {
+func ComputeBuildMetrics(snapshots []DaySnapshot, windowDays int) map[string]float64 {
 	if len(snapshots) == 0 {
 		return nil
 	}
@@ -321,16 +376,13 @@ func ComputeBuildMetrics(snapshots []DaySnapshot, windowDays int) []BuildMetrics
 	}
 	latest, err := time.Parse("2006-01-02", latestDate)
 	if err != nil {
-		// Fallback to now if date is unparseable.
 		latest = time.Now().UTC()
 	}
 	cutoff := latest.AddDate(0, 0, -windowDays)
 	cutoffStr := cutoff.Format("2006-01-02")
 
-	// Aggregate per app within window
 	type agg struct {
 		passed int
-		failed int
 		total  int
 	}
 	appData := make(map[string]*agg)
@@ -344,23 +396,15 @@ func ComputeBuildMetrics(snapshots []DaySnapshot, windowDays int) []BuildMetrics
 				appData[c.App] = &agg{}
 			}
 			appData[c.App].passed += c.Passed
-			appData[c.App].failed += c.Failed
 			appData[c.App].total += c.Total
 		}
 	}
 
-	result := make([]BuildMetrics, 0, len(appData))
+	result := make(map[string]float64, len(appData))
 	for app, a := range appData {
-		var rate float64
 		if a.total > 0 {
-			rate = float64(a.passed) / float64(a.total) * 100.0
+			result[app] = float64(a.passed) / float64(a.total) * 100.0
 		}
-		bm := BuildMetrics{
-			App:        app,
-			PassRate7d: rate,
-		}
-		result = append(result, bm)
 	}
-
 	return result
 }

--- a/stats-go/internal/testhub/collector_test.go
+++ b/stats-go/internal/testhub/collector_test.go
@@ -23,7 +23,6 @@ func TestAppendSnapshot_NewDay(t *testing.T) {
 	if len(result.Snapshots[0].BuildCounts) != 1 {
 		t.Errorf("expected 1 build count, got %d", len(result.Snapshots[0].BuildCounts))
 	}
-	// PullCount must survive the snapshot round-trip.
 	if result.Snapshots[0].Packages[0].PullCount != 42 {
 		t.Errorf("expected PullCount=42, got %d", result.Snapshots[0].Packages[0].PullCount)
 	}
@@ -32,7 +31,6 @@ func TestAppendSnapshot_NewDay(t *testing.T) {
 func TestAppendSnapshot_Idempotent(t *testing.T) {
 	store := &HistoryStore{}
 	today := time.Now().UTC().Format("2006-01-02")
-	// Pre-populate with today's snapshot
 	store.Snapshots = []DaySnapshot{
 		{Date: today, LastRunID: 50, BuildCounts: []AppDayCount{{App: "ghostty", Passed: 2, Failed: 0, Total: 2}}},
 	}
@@ -42,11 +40,9 @@ func TestAppendSnapshot_Idempotent(t *testing.T) {
 
 	result := AppendSnapshot(store, pkgs, counts, 100)
 
-	// Should still have exactly 1 snapshot (overwrites today's)
 	if len(result.Snapshots) != 1 {
 		t.Fatalf("expected 1 snapshot after idempotent append, got %d", len(result.Snapshots))
 	}
-	// Should be updated to latest data
 	if result.Snapshots[0].LastRunID != 100 {
 		t.Errorf("expected updated LastRunID=100, got %d", result.Snapshots[0].LastRunID)
 	}
@@ -67,7 +63,6 @@ func TestAppendSnapshot_Multipledays(t *testing.T) {
 
 	result := AppendSnapshot(store, pkgs, counts, 30)
 
-	// Today is a new day — should have 3 snapshots
 	if len(result.Snapshots) != 3 {
 		t.Fatalf("expected 3 snapshots, got %d", len(result.Snapshots))
 	}
@@ -75,41 +70,108 @@ func TestAppendSnapshot_Multipledays(t *testing.T) {
 
 // --- parseJobApp tests ---
 
-func TestParseJobApp_ValidX86(t *testing.T) {
-	app, ok := parseJobApp("compile-oci (ghostty, x86_64)")
+func TestParseJobApp_CompileOciX86(t *testing.T) {
+	r, ok := parseJobApp("compile-oci (ghostty, x86_64)")
 	if !ok {
-		t.Fatal("expected ok=true for valid x86_64 job")
+		t.Fatal("expected ok=true")
 	}
-	if app != "ghostty" {
-		t.Errorf("expected app=ghostty, got %q", app)
+	if r.App != "ghostty" {
+		t.Errorf("expected app=ghostty, got %q", r.App)
+	}
+	if r.Stage != "compile-oci" {
+		t.Errorf("expected stage=compile-oci, got %q", r.Stage)
+	}
+	if r.Arch != "x86_64" {
+		t.Errorf("expected arch=x86_64, got %q", r.Arch)
+	}
+	if !r.HasArch {
+		t.Error("expected HasArch=true")
 	}
 }
 
-func TestParseJobApp_SkipAarch64(t *testing.T) {
-	_, ok := parseJobApp("compile-oci (firefox-nightly, aarch64)")
-	if ok {
-		t.Fatal("expected ok=false for aarch64 job (should be skipped)")
+func TestParseJobApp_CompileOciAarch64(t *testing.T) {
+	r, ok := parseJobApp("compile-oci (firefox-nightly, aarch64)")
+	if !ok {
+		t.Fatal("expected ok=true for aarch64 (now tracked)")
+	}
+	if r.Arch != "aarch64" {
+		t.Errorf("expected arch=aarch64, got %q", r.Arch)
+	}
+	if !r.HasArch {
+		t.Error("expected HasArch=true")
 	}
 }
 
-func TestParseJobApp_NotCompileOci(t *testing.T) {
+func TestParseJobApp_SignAndPush(t *testing.T) {
+	r, ok := parseJobApp("sign-and-push (ghostty, x86_64)")
+	if !ok {
+		t.Fatal("expected ok=true for sign-and-push")
+	}
+	if r.Stage != "sign-and-push" {
+		t.Errorf("expected stage=sign-and-push, got %q", r.Stage)
+	}
+	if r.Arch != "x86_64" {
+		t.Errorf("expected arch=x86_64, got %q", r.Arch)
+	}
+}
+
+func TestParseJobApp_PublishManifestList(t *testing.T) {
+	r, ok := parseJobApp("publish-manifest-list (ghostty)")
+	if !ok {
+		t.Fatal("expected ok=true for publish-manifest-list")
+	}
+	if r.Stage != "publish-manifest-list" {
+		t.Errorf("expected stage=publish-manifest-list, got %q", r.Stage)
+	}
+	if r.Arch != "" {
+		t.Errorf("expected arch empty for publish-manifest-list, got %q", r.Arch)
+	}
+	if r.HasArch {
+		t.Error("expected HasArch=false for publish-manifest-list")
+	}
+}
+
+func TestParseJobApp_AnnotatePackages(t *testing.T) {
+	r, ok := parseJobApp("annotate-packages (ghostty, aarch64)")
+	if !ok {
+		t.Fatal("expected ok=true for annotate-packages")
+	}
+	if r.Stage != "annotate-packages" {
+		t.Errorf("expected stage=annotate-packages, got %q", r.Stage)
+	}
+}
+
+func TestParseJobApp_NotRecognised(t *testing.T) {
 	_, ok := parseJobApp("Build summary")
 	if ok {
-		t.Fatal("expected ok=false for non-compile-oci job")
+		t.Fatal("expected ok=false for unrecognised job")
 	}
 }
 
 func TestParseJobApp_HyphenatedApp(t *testing.T) {
-	app, ok := parseJobApp("compile-oci (firefox-nightly, x86_64)")
+	r, ok := parseJobApp("compile-oci (firefox-nightly, x86_64)")
 	if !ok {
 		t.Fatal("expected ok=true for hyphenated app name")
 	}
-	if app != "firefox-nightly" {
-		t.Errorf("expected app=firefox-nightly, got %q", app)
+	if r.App != "firefox-nightly" {
+		t.Errorf("expected app=firefox-nightly, got %q", r.App)
+	}
+}
+
+// TestParseJobApp_CaseNormalize verifies that mixed-case CI job names (Bug 7C)
+// are normalized to lowercase so the metric-to-package join succeeds.
+func TestParseJobApp_CaseNormalize(t *testing.T) {
+	r, ok := parseJobApp("compile-oci (io.github.DenysMb.Kontainer, x86_64)")
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if r.App != "io.github.denysmb.kontainer" {
+		t.Errorf("expected lowercase app name, got %q", r.App)
 	}
 }
 
 // --- ComputeBuildMetrics tests ---
+// ComputeBuildMetrics now returns map[string]float64.
 
 func TestComputeBuildMetrics_Empty(t *testing.T) {
 	metrics := ComputeBuildMetrics([]DaySnapshot{}, 7)
@@ -127,10 +189,10 @@ func TestComputeBuildMetrics_AllPassed(t *testing.T) {
 	}
 	metrics := ComputeBuildMetrics(snapshots, 7)
 	if len(metrics) != 1 {
-		t.Fatalf("expected 1 metric, got %d", len(metrics))
+		t.Fatalf("expected 1 entry, got %d", len(metrics))
 	}
-	if metrics[0].PassRate7d != 100.0 {
-		t.Errorf("expected PassRate7d=100.0, got %f", metrics[0].PassRate7d)
+	if metrics["ghostty"] != 100.0 {
+		t.Errorf("expected 100.0, got %f", metrics["ghostty"])
 	}
 }
 
@@ -142,8 +204,8 @@ func TestComputeBuildMetrics_AllFailed(t *testing.T) {
 		},
 	}
 	metrics := ComputeBuildMetrics(snapshots, 7)
-	if metrics[0].PassRate7d != 0.0 {
-		t.Errorf("expected PassRate7d=0.0 for all failures, got %f", metrics[0].PassRate7d)
+	if metrics["ghostty"] != 0.0 {
+		t.Errorf("expected 0.0 for all failures, got %f", metrics["ghostty"])
 	}
 }
 
@@ -159,31 +221,83 @@ func TestComputeBuildMetrics_Mixed(t *testing.T) {
 	}
 	metrics := ComputeBuildMetrics(snapshots, 7)
 	if len(metrics) != 2 {
-		t.Fatalf("expected 2 metrics, got %d", len(metrics))
+		t.Fatalf("expected 2 entries, got %d", len(metrics))
 	}
-	// Find ghostty
-	for _, m := range metrics {
-		if m.App == "ghostty" {
-			// 3/4 = 75%
-			if m.PassRate7d != 75.0 {
-				t.Errorf("ghostty: expected PassRate7d=75.0, got %f", m.PassRate7d)
-			}
-		}
+	// 3/4 = 75%
+	if metrics["ghostty"] != 75.0 {
+		t.Errorf("ghostty: expected 75.0, got %f", metrics["ghostty"])
 	}
 }
 
 func TestComputeBuildMetrics_ZeroTotal(t *testing.T) {
-	// Edge case: Total=0 must not panic (division by zero)
 	snapshots := []DaySnapshot{
 		{
 			Date:        "2024-01-01",
 			BuildCounts: []AppDayCount{{App: "ghostty", Passed: 0, Failed: 0, Total: 0}},
 		},
 	}
-	// Should not panic
+	// Total=0 should not panic and rate=0 → app absent from map
 	metrics := ComputeBuildMetrics(snapshots, 7)
-	if len(metrics) == 1 && metrics[0].PassRate7d != 0.0 {
-		t.Errorf("expected PassRate7d=0.0 for zero total, got %f", metrics[0].PassRate7d)
+	if rate, ok := metrics["ghostty"]; ok && rate != 0.0 {
+		t.Errorf("expected 0.0 or absent for zero total, got %f", rate)
+	}
+}
+
+func TestComputeBuildMetrics_WindowFiltering(t *testing.T) {
+	old := time.Now().UTC().AddDate(0, 0, -10).Format("2006-01-02")
+	recent := time.Now().UTC().AddDate(0, 0, -1).Format("2006-01-02")
+
+	snapshots := []DaySnapshot{
+		{
+			Date:        old,
+			BuildCounts: []AppDayCount{{App: "ghostty", Passed: 0, Failed: 10, Total: 10}},
+		},
+		{
+			Date:        recent,
+			BuildCounts: []AppDayCount{{App: "ghostty", Passed: 10, Failed: 0, Total: 10}},
+		},
+	}
+	metrics := ComputeBuildMetrics(snapshots, 7)
+	if len(metrics) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(metrics))
+	}
+	// 7-day window: old snapshot (10d ago) is outside window
+	if metrics["ghostty"] != 100.0 {
+		t.Errorf("expected 100.0 (old snapshot excluded), got %f", metrics["ghostty"])
+	}
+}
+
+// TestComputeBuildMetrics_30dField verifies that the 30d rate is not misassigned (Bug 7A).
+// The caller is responsible for assigning the return to the correct field; this test
+// verifies the map returns the correct value regardless of windowDays.
+func TestComputeBuildMetrics_30dField(t *testing.T) {
+	old := time.Now().UTC().AddDate(0, 0, -20).Format("2006-01-02")
+	recent := time.Now().UTC().AddDate(0, 0, -1).Format("2006-01-02")
+
+	snapshots := []DaySnapshot{
+		{
+			Date:        old,
+			BuildCounts: []AppDayCount{{App: "ghostty", Passed: 4, Failed: 0, Total: 4}},
+		},
+		{
+			Date:        recent,
+			BuildCounts: []AppDayCount{{App: "ghostty", Passed: 6, Failed: 0, Total: 6}},
+		},
+	}
+	rate7d := ComputeBuildMetrics(snapshots, 7)
+	rate30d := ComputeBuildMetrics(snapshots, 30)
+
+	// 7d window: only recent counts → 6/6 = 100%
+	if rate7d["ghostty"] != 100.0 {
+		t.Errorf("7d rate: expected 100.0, got %f", rate7d["ghostty"])
+	}
+	// 30d window: both snapshots count → 10/10 = 100%
+	if rate30d["ghostty"] != 100.0 {
+		t.Errorf("30d rate: expected 100.0, got %f", rate30d["ghostty"])
+	}
+	// Verify the two window results are independent (different map objects)
+	if &rate7d == &rate30d {
+		t.Error("expected independent map objects for 7d and 30d")
 	}
 }
 
@@ -250,31 +364,5 @@ func TestMergePackages_BackfillsMissingNames(t *testing.T) {
 	}
 	if got[0].VersionCount != 7 || got[0].Version != "1.2.3" {
 		t.Fatalf("expected existing ghostty metadata to win, got %+v", got[0])
-	}
-}
-
-func TestComputeBuildMetrics_WindowFiltering(t *testing.T) {
-	// Only snapshots within the window should count for PassRate7d
-	old := time.Now().UTC().AddDate(0, 0, -10).Format("2006-01-02")
-	recent := time.Now().UTC().AddDate(0, 0, -1).Format("2006-01-02")
-
-	snapshots := []DaySnapshot{
-		{
-			Date:        old,
-			BuildCounts: []AppDayCount{{App: "ghostty", Passed: 0, Failed: 10, Total: 10}},
-		},
-		{
-			Date:        recent,
-			BuildCounts: []AppDayCount{{App: "ghostty", Passed: 10, Failed: 0, Total: 10}},
-		},
-	}
-	metrics := ComputeBuildMetrics(snapshots, 7)
-	if len(metrics) != 1 {
-		t.Fatalf("expected 1 metric, got %d", len(metrics))
-	}
-	// 7-day window: old snapshot is 10 days ago, outside window
-	// Only recent snapshot counts → PassRate7d = 100%
-	if metrics[0].PassRate7d != 100.0 {
-		t.Errorf("expected PassRate7d=100.0 (old snapshot excluded by window), got %f", metrics[0].PassRate7d)
 	}
 }

--- a/stats-go/internal/testhub/collector_test.go
+++ b/stats-go/internal/testhub/collector_test.go
@@ -236,10 +236,10 @@ func TestComputeBuildMetrics_ZeroTotal(t *testing.T) {
 			BuildCounts: []AppDayCount{{App: "ghostty", Passed: 0, Failed: 0, Total: 0}},
 		},
 	}
-	// Total=0 should not panic and rate=0 → app absent from map
+	// Total=0 → app should be absent from map (no entry added for zero total)
 	metrics := ComputeBuildMetrics(snapshots, 7)
-	if rate, ok := metrics["ghostty"]; ok && rate != 0.0 {
-		t.Errorf("expected 0.0 or absent for zero total, got %f", rate)
+	if _, ok := metrics["ghostty"]; ok {
+		t.Error("expected ghostty absent from map for zero total")
 	}
 }
 
@@ -295,10 +295,12 @@ func TestComputeBuildMetrics_30dField(t *testing.T) {
 	if rate30d["ghostty"] != 100.0 {
 		t.Errorf("30d rate: expected 100.0, got %f", rate30d["ghostty"])
 	}
-	// Verify the two window results are independent (different map objects)
-	if &rate7d == &rate30d {
+	// Verify the two window results are independent maps.
+	rate7d["__test__"] = -1
+	if _, found := rate30d["__test__"]; found {
 		t.Error("expected independent map objects for 7d and 30d")
 	}
+	delete(rate7d, "__test__")
 }
 
 // --- isTesthubPackage / stripTesthubPrefix tests ---

--- a/stats-go/internal/testhub/types.go
+++ b/stats-go/internal/testhub/types.go
@@ -10,21 +10,42 @@ type Package struct {
 	UpdatedAt    string `json:"updated_at,omitempty"`
 }
 
-// AppDayCount stores raw pass/fail counts per app per day
-type AppDayCount struct {
-	App    string `json:"app"`
-	Passed int    `json:"passed"`
-	Failed int    `json:"failed"`
-	Total  int    `json:"total"`
+// JobParseResult is the typed result of parsing a CI job name.
+// HasArch is false only for publish-manifest-list (which has no arch suffix).
+type JobParseResult struct {
+	App     string // lowercased, trimmed
+	Stage   string // "compile-oci" | "sign-and-push" | "publish-manifest-list" | "annotate-packages"
+	Arch    string // "x86_64" | "aarch64" | "" (publish-manifest-list only)
+	HasArch bool
 }
 
-// BuildMetrics is computed from raw counts — never stored in history
+// AppDayCount stores raw pass/fail counts per app per day.
+// Compile-oci cancelled runs count as failures (cascade origin).
+// Non-compile stages only count explicit "failure" conclusions (not cancelled).
+type AppDayCount struct {
+	App            string `json:"app"`
+	Passed         int    `json:"passed"`          // compile-oci x86_64 success
+	Failed         int    `json:"failed"`           // compile-oci x86_64 failure or cancelled
+	PassedAarch64  int    `json:"passed_aarch64"`   // compile-oci aarch64 success
+	FailedAarch64  int    `json:"failed_aarch64"`   // compile-oci aarch64 failure or cancelled
+	SignFailed     int    `json:"sign_failed"`       // sign-and-push failure (not cancelled)
+	PublishFailed  int    `json:"publish_failed"`    // publish-manifest-list failure (not cancelled)
+	AnnotateFailed int    `json:"annotate_failed"`   // annotate-packages failure (not cancelled)
+	Total          int    `json:"total"`
+}
+
+// BuildMetrics is computed from raw counts — never stored in history.
+// LastStatus values: "passing" | "failing" | "stale" | "pending" | "unknown"
+//   "stale"   — has 30d history but no 7d activity (builds went silent)
+//   "pending" — zero build history (new package or never triggered)
 type BuildMetrics struct {
-	App         string  `json:"app"`
-	PassRate7d  float64 `json:"pass_rate_7d"`
-	PassRate30d float64 `json:"pass_rate_30d"`
-	LastStatus  string  `json:"last_status"`
-	LastBuildAt string  `json:"last_build_at"`
+	App           string  `json:"app"`
+	PassRate7d    float64 `json:"pass_rate_7d"`
+	PassRate30d   float64 `json:"pass_rate_30d"`
+	LastStatus    string  `json:"last_status"`
+	LastBuildAt   string  `json:"last_build_at"`
+	Arch86Status  string  `json:"arch_x86_status"`  // "passing" | "failing" | "unknown"
+	ArchArmStatus string  `json:"arch_arm_status"`  // "passing" | "failing" | "unknown"
 }
 
 type DaySnapshot struct {

--- a/tests/e2e/charts.spec.ts
+++ b/tests/e2e/charts.spec.ts
@@ -405,18 +405,57 @@ test.describe('Testhub data quality', () => {
     expect(normalized).toContain('LATEST BUILD STATUS');
     expect(normalized).toContain('UPDATED THIS WEEK');
     expect(normalized).toContain('BUILD RUNS (30D)');
-    // 'TOTAL PULLS' is conditional — omitted until OCI pull API available (#13)
   });
 
   test('Package table has all expected column headers', async ({ page }) => {
     const headers = await page.locator('#testhub-table thead th').allTextContents();
     const text = headers.join(' ');
     expect(text).toContain('Package');
-    expect(text).toContain('Version');
     expect(text).toContain('Build Status');
-    expect(text).toContain('Last Build');
+    expect(text).toContain('Arch');
+    expect(text).toContain('Last Published');
     expect(text).not.toContain('Version Count');
     expect(text).not.toContain('Pulls');
+  });
+
+  // Pre-deploy structural: verify status badge element exists in at least one row
+  test('Status badge element is present in table rows', async ({ page }) => {
+    const badge = page.locator('#testhub-tbody .status-badge').first();
+    await expect(badge).toBeAttached();
+  });
+
+  // Pre-deploy structural: arch cell is present in at least one row
+  test('Arch cell is present in table rows', async ({ page }) => {
+    const archCell = page.locator('#testhub-tbody .arch-cell').first();
+    await expect(archCell).toBeAttached();
+  });
+
+  // Pre-deploy structural: freshness banner element exists (hidden by default)
+  test('Freshness banner element exists in DOM', async ({ page }) => {
+    const banner = page.locator('#freshness-banner');
+    await expect(banner).toBeAttached();
+  });
+
+  // Pre-deploy structural: CI runs link is present
+  test('View CI Runs link is present', async ({ page }) => {
+    const link = page.locator('a[href*="actions/workflows/build.yml"]');
+    await expect(link).toBeAttached();
+  });
+
+  // Pre-deploy enum validation: last_status must be a known valid value
+  test('build_metrics last_status values are valid enum members', async ({ page }) => {
+    const rows = page.locator('#testhub-tbody tr');
+    const count = await rows.count();
+    if (count === 0) return; // cold cache — skip
+    const validStatuses = new Set(['passing', 'failing', 'stale', 'pending', 'unknown']);
+    for (let i = 0; i < Math.min(count, 5); i++) {
+      const badge = rows.nth(i).locator('.status-badge');
+      const cls = await badge.getAttribute('class');
+      if (!cls) continue;
+      // Extract the status class (passing|failing|stale|pending|unknown)
+      const statusCls = cls.split(' ').find(c => validStatuses.has(c));
+      expect(statusCls, `Row ${i} badge class must be a known status`).toBeTruthy();
+    }
   });
 });
 

--- a/tests/e2e/charts.spec.ts
+++ b/tests/e2e/charts.spec.ts
@@ -451,7 +451,8 @@ test.describe('Testhub data quality', () => {
     for (let i = 0; i < Math.min(count, 5); i++) {
       const badge = rows.nth(i).locator('.status-badge');
       const cls = await badge.getAttribute('class');
-      if (!cls) continue;
+      expect(cls, `Row ${i} must have a .status-badge with a class`).toBeTruthy();
+      if (!cls) continue; // type guard only — expect above already fails
       // Extract the status class (passing|failing|stale|pending|unknown)
       const statusCls = cls.split(' ').find(c => validStatuses.has(c));
       expect(statusCls, `Row ${i} badge class must be a known status`).toBeTruthy();


### PR DESCRIPTION
Fix 7 root causes preventing the status page from accurately reflecting the live state of packages in projectbluefin/testhub:

RC1 - 7d-only merge loop silently drops packages not built in last 7 days
  - Union 7d+30d windows; apps only in 30d window get status='stale'
  - Apps in flatpak inventory with no history at all get status='pending'
  - computeLastStatus now checks PublishFailed for pipeline failures

RC2 - No branch filter on FetchBuildCounts
  - Add --branch main to gh run list; add HeadBranch to ghRunRecord
  - Bump limit 50→100

RC3 - Only compile-oci tracked; sign/publish/annotate invisible
  - New typed JobParseResult struct replaces raw (string,bool) return
  - All 4 pipeline stages parsed with correct per-stage failure counters
  - publish-manifest-list has no arch suffix (HasArch=false)

RC4 - No dedicated testhub history cache
  - Add testhub-history-v1 restore+save scoped to single file (path: .sync-cache/testhub-history.json, NOT full dir)
  - Add timeout-minutes: 5 on fetch step

RC5/6 - No freshness indicator or CI link in UI
  - Client-side freshness banner fires when data is >48h old
  - 'View CI Runs →' link added to page header

RC7A - ComputeBuildMetrics always assigned rate to PassRate7d
  - Changed return type to map[string]float64; callers assign correctly

RC7B - In-progress runs advance cursor permanently (Bug 7B)
  - Skip runs where status != 'completed'

RC7C - Case mismatch breaks metric-to-package join
  - strings.ToLower() in parseJobApp normalizes all app names

RC7D - Cascade cancellations inflate non-compile failure counters
  - compile-oci: count failure+cancelled
  - sign-and-push, publish-manifest-list, annotate-packages: failure only

UI changes:
  - 4-state status badges: passing/failing/stale/pending
  - Per-arch inline icons (x86/arm) next to each status badge
  - Merged 'Last Published' column (GHCR updated_at primary, CI date tooltip)

Tests:
  - Updated all existing tests for new ComputeBuildMetrics map return type
  - Added tests for all 4 job stage parsers, case normalization, 30d field independence, aarch64 tracking
  - Updated E2E tests: new column headers, structural badge/arch presence, freshness banner existence, CI runs link, enum validation

Assisted-by: Claude Sonnet 4.6 via GitHub Copilot